### PR TITLE
fix: ajusta o campo 'name' no composer.json para o padrão válido do C…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "felipeArnold/filament-multi-tenancy-start-kit",
+    "name": "felipearnold/filament-multi-tenancy-start-kit",
     "type": "project",
     "description": "The skeleton application for the Laravel framework.",
     "keywords": ["laravel", "framework"],


### PR DESCRIPTION
O campo "name" no 'composer.json' estava violando o schema oficial do Composer, pois continha letras maiúsculas.

Alterei para '"felipearnold/filament-multi-tenancy-start-kit"', seguindo o padrão recomendado:
- Tudo em minúsculas
- Formato vendor/package

Isso permite que 'composer install' funcione corretamente logo após o clone do projeto.